### PR TITLE
chore(cd): conditional run JSR publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,15 @@ jobs:
           TURBO_TELEMETRY_DISABLED: 1
 
       - name: JSR versioning
+        if: github.head_ref == 'changeset-release/main'
         run: pnpm dlx tsx ./scripts/jsr-versioning.ts
 
       - name: Publish @kaiverse/signal to JSR
+        if: github.head_ref == 'changeset-release/main'
         run: pnpm dlx jsr publish --allow-dirty
         working-directory: ./packages/signal
 
       - name: Publish @kaiverse/signal-react to JSR
+        if: github.head_ref == 'changeset-release/main'
         run: pnpm dlx jsr publish --allow-dirty
         working-directory: ./packages/signal-react


### PR DESCRIPTION
Only run JSR publish steps when PRs from branch `changeset-release/main` merged into main. 
Ensure publish to both npm & JSR in the same job.