### PR TITLE
chore(cd): separate JSR publishing to another workflow

### DIFF
--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -1,20 +1,20 @@
-name: Release
+name: Publish to JSR
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Versioning and publish to NPM
-    permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+  publish-jsr:
+    name: Publish to JSR
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'changeset-release/main'
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -47,21 +47,13 @@ jobs:
         env:
           TURBO_TELEMETRY_DISABLED: 1
 
-      - name: Creating .npmrc
-        run: |
-          cat << EOF > "$HOME/.npmrc"
-            //registry.npmjs.org/:_authToken=$NPM_TOKEN
-          EOF
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: JSR versioning
+        run: pnpm dlx tsx ./scripts/jsr-versioning.ts
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          publish: pnpm publish:npm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          TURBO_TELEMETRY_DISABLED: 1
+      - name: Publish @kaiverse/signal to JSR
+        run: pnpm dlx jsr publish --allow-dirty
+        working-directory: ./packages/signal
+
+      - name: Publish @kaiverse/signal-react to JSR
+        run: pnpm dlx jsr publish --allow-dirty
+        working-directory: ./packages/signal-react


### PR DESCRIPTION
Conditional publish to JSR. Only run when a PR from `changeset-release/main` successfully merged into main.